### PR TITLE
Reset array keys when chunking tracks

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -255,11 +255,11 @@ Route::group(['middleware' => ['web']], function () {
                 // Replace the first chunk of Tracks
                 // Basically clears the Playlist to start fresh
                 if (!$key) {
-                    $api->replaceUserPlaylistTracks(Auth::user()->spotify_id, $spotifyPlaylist->id, $chunk->toArray());
+                    $api->replaceUserPlaylistTracks(Auth::user()->spotify_id, $spotifyPlaylist->id, array_values($chunk->toArray()));
 
                 // Add to the Spotify Playlist
                 } else {
-                    $api->addUserPlaylistTracks(Auth::user()->spotify_id, $spotifyPlaylist->id, $chunk->toArray());
+                    $api->addUserPlaylistTracks(Auth::user()->spotify_id, $spotifyPlaylist->id, array_values($chunk->toArray()));
                 }
             }
 


### PR DESCRIPTION
As the track limit is 100 the API library was looping through tracks by key id and expecting every array to start from index 0 which doesn't happen when using Laravel's Eloquent `chunk(100)`

Created a Pull Request on that library too as well as fix here for the short term.

Fixes: #1 